### PR TITLE
Feature/cmake version in variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-cmake_minimum_required(VERSION 3.23.1)
+set(CMakeMinimumVersion 3.23.1)
+
+cmake_minimum_required(VERSION ${CMakeMinimumVersion})
 
 set(ProjectName CHANGE_ME) # <Var name> <Name of the project>
 set(ProjectRunName ${ProjectName}_Run) # <Var name> <Name of the executable>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMakeMinimumVersion 3.23.1)
+set(CMakeMinimumVersion 3.22.1)
 
 cmake_minimum_required(VERSION ${CMakeMinimumVersion})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION ${CMakeMinimumVersion})
 
 # Add headers here. If no headers, leave empty.
 set(Headers

--- a/src/Example/CMakeLists.txt
+++ b/src/Example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION ${CMakeMinimumVersion})
 
 # Add headers here
 set(Headers

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23.1)
+cmake_minimum_required(VERSION ${CMakeMinimumVersion})
 
 # Add test source files here
 set(Sources


### PR DESCRIPTION
Currently the minimum CMake version is replicated in multiple files. I propose to replace that with a global variable in the root CMakeLists.txt.
Note that this branch leverages CMake version 3.22, since VScode on my Ubuntu box is not more recent.